### PR TITLE
#4 Deepen response-handling seam: one error interpretation, domain return types

### DIFF
--- a/src/main/kotlin/HomemoneyApiClient.kt
+++ b/src/main/kotlin/HomemoneyApiClient.kt
@@ -7,7 +7,11 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import ru.levar.api.HomemoneyApiService
+import ru.levar.api.dto.ApiEnvelope
 import ru.levar.domain.Account
+import ru.levar.domain.AccountGroup
+import ru.levar.domain.Category
+import ru.levar.domain.Transaction
 import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger {}
@@ -53,16 +57,13 @@ class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
         clientId: String,
         clientSecret: String,
     ): Boolean {
-        try {
-            val response = apiService.login(login, password, clientId, clientSecret)
-            if (!response.isSuccessful || response.body()?.error?.code != 0) {
-                throw Exception("Authentication failed: ${response.body()?.error ?: response.message()}")
-            }
-            token = response.body()!!.token
-            return true
+        return try {
+            val auth = handleResponse(apiService.login(login, password, clientId, clientSecret))
+            token = auth.token
+            true
         } catch (e: Exception) {
             logger.error(e) { "Authentication failed: ${e.message}" }
-            return false
+            false
         }
     }
 
@@ -70,33 +71,24 @@ class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
         require(_token.isNotBlank()) { "Authentication required. Call login() first." }
     }
 
-    suspend fun getAccountGroups(): ru.levar.api.dto.BalanceListResponse {
+    suspend fun getAccountGroups(): List<AccountGroup> {
         requireAuthentication()
         val response = apiService.getAccountGroups(token)
-        return handleResponse(response)
+        return handleResponse(response).listAccountGroupInfo
     }
 
-    suspend fun getAccounts(): List<Account> {
-        val accGroups = getAccountGroups()
-        val accounts = mutableListOf<Account>()
-        for (accGroup in accGroups.listAccountGroupInfo) {
-            for (acc in accGroup.listAccountInfo) {
-                accounts.add(acc)
-            }
-        }
-        return accounts
-    }
+    suspend fun getAccounts(): List<Account> = getAccountGroups().flatMap { it.listAccountInfo }
 
-    suspend fun getCategories(): ru.levar.api.dto.CategoryListResponse {
+    suspend fun getCategories(): List<Category> {
         requireAuthentication()
         val response = apiService.getCategories(token)
-        return handleResponse(response)
+        return handleResponse(response).listCategory
     }
 
-    suspend fun getTransactions(topCount: Int?): ru.levar.api.dto.TransactionListResponse {
+    suspend fun getTransactions(topCount: Int?): List<Transaction> {
         requireAuthentication()
         val response = apiService.getTransactions(token, topCount)
-        return handleResponse(response)
+        return handleResponse(response).listTransaction
     }
 
 //    suspend fun getTransactions(
@@ -129,15 +121,18 @@ class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
 //        return handleResponse(response)
 //    }
 
-    private fun <T> handleResponse(response: Response<T>): T {
+    private fun <T : ApiEnvelope> handleResponse(response: Response<T>): T {
         if (!response.isSuccessful) {
             throw Exception("Request failed with code ${response.code()}: ${response.message()}")
         }
 
-        val body = response.body()!!
-//        if (body == null || body.error?.code != 0) {
-//            throw Exception("API error: ${body?.error?.message ?: "Unknown error"}")
-//        }
+        val body =
+            response.body()
+                ?: throw Exception("Request failed: empty response body")
+
+        if (body.error.code != 0) {
+            throw Exception("API error ${body.error.code}: ${body.error.message}")
+        }
 
         return body
     }

--- a/src/main/kotlin/api/HomemoneyApiService.kt
+++ b/src/main/kotlin/api/HomemoneyApiService.kt
@@ -8,7 +8,7 @@ import ru.levar.api.dto.BalanceListResponse
 import ru.levar.api.dto.CategoryListResponse
 import ru.levar.api.dto.TransactionListResponse
 
-interface HomemoneyApiService {
+internal interface HomemoneyApiService {
     @GET("TokenPassword")
     suspend fun login(
         @Query("username") login: String,

--- a/src/main/kotlin/ru/levar/api/dto/ApiEnvelope.kt
+++ b/src/main/kotlin/ru/levar/api/dto/ApiEnvelope.kt
@@ -1,0 +1,14 @@
+package ru.levar.api.dto
+
+import ru.levar.domain.ErrorType
+
+/**
+ * Common contract for every API response envelope.
+ *
+ * Every endpoint wraps its payload alongside an [ErrorType]. Exposing it through
+ * a single interface lets the client interpret HTTP status and API error code at
+ * one point, regardless of the concrete envelope.
+ */
+internal interface ApiEnvelope {
+    val error: ErrorType
+}

--- a/src/main/kotlin/ru/levar/api/dto/AuthResponse.kt
+++ b/src/main/kotlin/ru/levar/api/dto/AuthResponse.kt
@@ -3,8 +3,8 @@ package ru.levar.api.dto
 import com.google.gson.annotations.SerializedName
 import ru.levar.domain.ErrorType
 
-data class AuthResponse(
-    @SerializedName("Error") val error: ErrorType,
+internal data class AuthResponse(
+    @SerializedName("Error") override val error: ErrorType,
     @SerializedName("access_token") val token: String,
     @SerializedName("refresh_token") val refreshToken: String,
-)
+) : ApiEnvelope

--- a/src/main/kotlin/ru/levar/api/dto/BalanceListResponse.kt
+++ b/src/main/kotlin/ru/levar/api/dto/BalanceListResponse.kt
@@ -4,9 +4,9 @@ import com.google.gson.annotations.SerializedName
 import ru.levar.domain.AccountGroup
 import ru.levar.domain.ErrorType
 
-data class BalanceListResponse(
+internal data class BalanceListResponse(
     @SerializedName("defaultcurrency") val defaultCurrencyId: String,
     @SerializedName("name") val currencyShortName: String,
     @SerializedName("ListGroupInfo") val listAccountGroupInfo: List<AccountGroup>,
-    @SerializedName("Error") val error: ErrorType,
-)
+    @SerializedName("Error") override val error: ErrorType,
+) : ApiEnvelope

--- a/src/main/kotlin/ru/levar/api/dto/CategoryListResponse.kt
+++ b/src/main/kotlin/ru/levar/api/dto/CategoryListResponse.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import ru.levar.domain.Category
 import ru.levar.domain.ErrorType
 
-data class CategoryListResponse(
+internal data class CategoryListResponse(
     @SerializedName("ListCategory") val listCategory: List<Category>,
-    @SerializedName("Error") val error: ErrorType,
-)
+    @SerializedName("Error") override val error: ErrorType,
+) : ApiEnvelope

--- a/src/main/kotlin/ru/levar/api/dto/TransactionListResponse.kt
+++ b/src/main/kotlin/ru/levar/api/dto/TransactionListResponse.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import ru.levar.domain.ErrorType
 import ru.levar.domain.Transaction
 
-data class TransactionListResponse(
+internal data class TransactionListResponse(
     @SerializedName("ListTransaction") val listTransaction: List<Transaction>,
-    @SerializedName("Error") val error: ErrorType,
-)
+    @SerializedName("Error") override val error: ErrorType,
+) : ApiEnvelope

--- a/src/test/kotlin/ru/levar/integration/ApiIntegrationTest.kt
+++ b/src/test/kotlin/ru/levar/integration/ApiIntegrationTest.kt
@@ -155,11 +155,11 @@ class ApiIntegrationTest {
             assertThat(accounts).hasSize(1)
             assertThat(accounts[0].name).isEqualTo("Cash")
 
-            assertThat(categories.listCategory).hasSize(1)
-            assertThat(categories.listCategory[0].name).isEqualTo("Food")
+            assertThat(categories).hasSize(1)
+            assertThat(categories[0].name).isEqualTo("Food")
 
-            assertThat(transactions.listTransaction).hasSize(1)
-            assertThat(transactions.listTransaction[0].total).isEqualTo(120.00)
+            assertThat(transactions).hasSize(1)
+            assertThat(transactions[0].total).isEqualTo(120.00)
 
             // Verify all requests were made
             assertThat(mockWebServer.requestCount).isEqualTo(4)
@@ -350,8 +350,8 @@ class ApiIntegrationTest {
 
             // Assert - Should handle empty lists gracefully
             assertThat(accounts).isEmpty()
-            assertThat(categories.listCategory).isEmpty()
-            assertThat(transactions.listTransaction).isEmpty()
+            assertThat(categories).isEmpty()
+            assertThat(transactions).isEmpty()
         }
 
     @Test
@@ -503,7 +503,7 @@ class ApiIntegrationTest {
             val transactions = apiClient.getTransactions(5)
 
             // Assert
-            assertThat(transactions.listTransaction).hasSize(1)
+            assertThat(transactions).hasSize(1)
 
             val request = mockWebServer.takeRequest() // Login
             val transRequest = mockWebServer.takeRequest() // Transactions

--- a/src/test/kotlin/ru/levar/unit/EdgeCaseTest.kt
+++ b/src/test/kotlin/ru/levar/unit/EdgeCaseTest.kt
@@ -205,9 +205,9 @@ class EdgeCaseTest {
             val result = apiClient.getTransactions(null)
 
             // Assert
-            assertThat(result.listTransaction).hasSize(1000)
-            assertThat(result.listTransaction.first().id).isEqualTo("trans1")
-            assertThat(result.listTransaction.last().id).isEqualTo("trans1000")
+            assertThat(result).hasSize(1000)
+            assertThat(result.first().id).isEqualTo("trans1")
+            assertThat(result.last().id).isEqualTo("trans1000")
         }
 
     @Test
@@ -499,7 +499,7 @@ class EdgeCaseTest {
             val result = apiClient.getAccountGroups()
 
             // Assert
-            assertThat(result.listAccountGroupInfo[0].listAccountInfo[0].listCurrencyInfo).isEmpty()
+            assertThat(result[0].listAccountInfo[0].listCurrencyInfo).isEmpty()
         }
 
     @Test
@@ -528,9 +528,9 @@ class EdgeCaseTest {
             val result3 = apiClient.getCategories()
 
             // Assert - All should succeed
-            assertThat(result1.listCategory).isEmpty()
-            assertThat(result2.listCategory).isEmpty()
-            assertThat(result3.listCategory).isEmpty()
+            assertThat(result1).isEmpty()
+            assertThat(result2).isEmpty()
+            assertThat(result3).isEmpty()
             assertThat(mockWebServer.requestCount).isEqualTo(3)
         }
 
@@ -558,7 +558,7 @@ class EdgeCaseTest {
             val result = apiClient.getCategories()
 
             // Assert
-            assertThat(result.listCategory).isEmpty()
+            assertThat(result).isEmpty()
         }
 
     @Test
@@ -583,7 +583,7 @@ class EdgeCaseTest {
             val result = apiClient.getTransactions(0)
 
             // Assert
-            assertThat(result.listTransaction).isEmpty()
+            assertThat(result).isEmpty()
 
             val request = mockWebServer.takeRequest()
             assertThat(request.path).contains("TopCount=0")
@@ -611,7 +611,7 @@ class EdgeCaseTest {
             val result = apiClient.getTransactions(-1)
 
             // Assert
-            assertThat(result.listTransaction).isEmpty()
+            assertThat(result).isEmpty()
 
             val request = mockWebServer.takeRequest()
             assertThat(request.path).contains("TopCount=-1")

--- a/src/test/kotlin/ru/levar/unit/HomemoneyApiClientEnhancedTest.kt
+++ b/src/test/kotlin/ru/levar/unit/HomemoneyApiClientEnhancedTest.kt
@@ -121,9 +121,8 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.getAccountGroups()
 
                 // Assert
-                result.listAccountGroupInfo shouldHaveSize 1
-                result.listAccountGroupInfo[0].name shouldBe "Personal Accounts"
-                result.defaultCurrencyId shouldBe TestDataFactory.DEFAULT_CURRENCY_ID
+                result shouldHaveSize 1
+                result[0].name shouldBe "Personal Accounts"
             }
         }
 
@@ -193,9 +192,9 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.getCategories()
 
                 // Assert
-                result.listCategory shouldHaveSize 2
-                result.listCategory[0].type shouldBe 0 // Expense
-                result.listCategory[1].type shouldBe 1 // Income
+                result shouldHaveSize 2
+                result[0].type shouldBe 0 // Expense
+                result[1].type shouldBe 1 // Income
             }
         }
 
@@ -208,7 +207,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.getCategories()
 
                 // Assert
-                result.listCategory.shouldBeEmpty()
+                result.shouldBeEmpty()
             }
         }
     }
@@ -237,9 +236,9 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.getTransactions(10)
 
                 // Assert
-                result.listTransaction shouldHaveSize 1
-                result.listTransaction[0].id shouldBe "trans1"
-                result.listTransaction[0].total shouldBe 125.50
+                result shouldHaveSize 1
+                result[0].id shouldBe "trans1"
+                result[0].total shouldBe 125.50
 
                 // Verify request
                 val request = mockWebServer.takeRequest()
@@ -256,7 +255,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.getTransactions(null)
 
                 // Assert
-                result.listTransaction.shouldBeEmpty()
+                result.shouldBeEmpty()
 
                 // Verify request doesn't include TopCount
                 val request = mockWebServer.takeRequest()
@@ -310,6 +309,50 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                         apiClient.getCategories()
                     }
                 exception.message shouldContain "500"
+            }
+        }
+
+        it("should throw when getTransactions returns API error on HTTP 200") {
+            runTest {
+                // Arrange: HTTP 200 with a non-zero API error code
+                mockWebServer.enqueueSuccess(
+                    """
+                    {
+                        "ListTransaction": [],
+                        "Error": {"code": 7, "message": "Token expired"}
+                    }
+                    """.trimIndent(),
+                )
+
+                // Act & Assert
+                val exception =
+                    shouldThrow<Exception> {
+                        apiClient.getTransactions(10)
+                    }
+                exception.message shouldContain "Token expired"
+            }
+        }
+
+        it("should throw when getAccountGroups returns API error on HTTP 200") {
+            runTest {
+                // Arrange: HTTP 200 with a non-zero API error code
+                mockWebServer.enqueueSuccess(
+                    """
+                    {
+                        "defaultcurrency": "980",
+                        "name": "UAH",
+                        "ListGroupInfo": [],
+                        "Error": {"code": 7, "message": "Token expired"}
+                    }
+                    """.trimIndent(),
+                )
+
+                // Act & Assert
+                val exception =
+                    shouldThrow<Exception> {
+                        apiClient.getAccountGroups()
+                    }
+                exception.message shouldContain "Token expired"
             }
         }
     }

--- a/src/test/kotlin/ru/levar/unit/HomemoneyApiClientTest.kt
+++ b/src/test/kotlin/ru/levar/unit/HomemoneyApiClientTest.kt
@@ -158,11 +158,9 @@ class HomemoneyApiClientTest {
             val result = apiClient.getAccountGroups()
 
             // Assert
-            assertThat(result.defaultCurrencyId).isEqualTo("980")
-            assertThat(result.currencyShortName).isEqualTo("UAH")
-            assertThat(result.listAccountGroupInfo).hasSize(1)
-            assertThat(result.listAccountGroupInfo[0].name).isEqualTo("Main Accounts")
-            assertThat(result.listAccountGroupInfo[0].listAccountInfo).hasSize(1)
+            assertThat(result).hasSize(1)
+            assertThat(result[0].name).isEqualTo("Main Accounts")
+            assertThat(result[0].listAccountInfo).hasSize(1)
 
             // Verify request
             val request = mockWebServer.takeRequest()
@@ -287,11 +285,11 @@ class HomemoneyApiClientTest {
             val result = apiClient.getCategories()
 
             // Assert
-            assertThat(result.listCategory).hasSize(2)
-            assertThat(result.listCategory[0].name).isEqualTo("Food")
-            assertThat(result.listCategory[0].type).isEqualTo(0)
-            assertThat(result.listCategory[1].name).isEqualTo("Salary")
-            assertThat(result.listCategory[1].type).isEqualTo(1)
+            assertThat(result).hasSize(2)
+            assertThat(result[0].name).isEqualTo("Food")
+            assertThat(result[0].type).isEqualTo(0)
+            assertThat(result[1].name).isEqualTo("Salary")
+            assertThat(result[1].type).isEqualTo(1)
 
             // Verify request
             val request = mockWebServer.takeRequest()
@@ -341,10 +339,10 @@ class HomemoneyApiClientTest {
             val result = apiClient.getTransactions(10)
 
             // Assert
-            assertThat(result.listTransaction).hasSize(1)
-            assertThat(result.listTransaction[0].id).isEqualTo("trans1")
-            assertThat(result.listTransaction[0].total).isEqualTo(150.50)
-            assertThat(result.listTransaction[0].description).isEqualTo("Weekly shopping")
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo("trans1")
+            assertThat(result[0].total).isEqualTo(150.50)
+            assertThat(result[0].description).isEqualTo("Weekly shopping")
 
             // Verify request
             val request = mockWebServer.takeRequest()
@@ -375,12 +373,38 @@ class HomemoneyApiClientTest {
             val result = apiClient.getTransactions(null)
 
             // Assert
-            assertThat(result.listTransaction).isEmpty()
+            assertThat(result).isEmpty()
 
             // Verify request doesn't include TopCount parameter
             val request = mockWebServer.takeRequest()
             assertThat(request.path).contains("TransactionList")
             assertThat(request.path).doesNotContain("TopCount")
+        }
+
+    @Test
+    fun `getCategories should throw when API returns error code on HTTP 200`() =
+        runTest {
+            // Arrange: HTTP 200 but API-level error in the Error envelope
+            val mockResponse =
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "ListCategory": [],
+                            "Error": {"code": 5, "message": "Session expired"}
+                        }
+                        """.trimIndent(),
+                    )
+            mockWebServer.enqueue(mockResponse)
+            apiClient.token = "test-token"
+
+            // Act & Assert
+            val exception =
+                assertThrows<Exception> {
+                    apiClient.getCategories()
+                }
+            assertThat(exception.message).contains("Session expired")
         }
 
     @Test


### PR DESCRIPTION
Closes #4

## Summary

Deepens the response-handling seam so a single module interprets every response and the client returns domain types instead of transport DTOs.

- **One interpretation point.** `handleResponse` now validates **HTTP status** and the API **`Error.code`** in one place (the commented-out check is gone). An API error returned on an HTTP 200 now throws for `getAccountGroups`, `getCategories`, and `getTransactions` — previously it was silently swallowed and only `login` checked it.
- **Domain types at the seam.** Public methods return domain types:
  - `getCategories()` → `List<Category>`
  - `getTransactions(topCount)` → `List<Transaction>`
  - `getAccountGroups()` → `List<AccountGroup>`
  - `getAccounts()` → `List<Account>` (unchanged)
- **`login()` shares the seam.** Routes through the same `handleResponse`, dropping the duplicated inline `Error.code` check.
- **DTOs are implementation-private.** New `ApiEnvelope` interface unifies the `Error` envelope; `ru.levar.api.dto.*` and the Retrofit `HomemoneyApiService` are now `internal`, so no DTO type appears in the client's public interface. Tests in the same module still exercise the transport layer directly.

## Approach

Built with TDD (red → green per the `/tdd` skill). Tracer bullet was the API-error-on-200 case for `getCategories`; subsequent cycles changed return types method-by-method (Kotlin compile-coupling means each return-type change updates that method's tests in the same cycle), then `login` was refactored onto the seam while green.

## Acceptance criteria

- [x] A single interpretation point validates both HTTP status and the API `Error.code`
- [x] An API error on HTTP 200 throws for `getCategories`, `getTransactions`, `getAccountGroups`
- [x] Those three return domain types, not `ru.levar.api.dto.*`
- [x] No `ru.levar.api.dto.*` type in the public interface of `HomemoneyApiClient`
- [x] `login()` error handling goes through the same interpretation point
- [x] Existing tests assert on domain types; error tests cover the API-error-on-200 case
- [x] `./gradlew test` passes (full `./gradlew build`, incl. ktlint, also passes)

## Testing

`./gradlew build` — BUILD SUCCESSFUL (tests + ktlint over main and test source sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)