### PR TITLE
#7 Make the error seam a type: introduce ApiFailure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,11 @@ suspend fun getAccounts(): List<Account> {
 ```
 
 ### Response Handling
-- `handleResponse<T>()` validates HTTP status and extracts body
-- Login has custom error handling (checks error.code == 0)
-- Throws exceptions on API errors with descriptive messages
+- `interpret<T>()` is the single seam: it validates HTTP status, the response body, and the API `Error.code` at one point, returning an `ApiResult<T>` (`Ok`/`Err`)
+- Failures cross the seam as a typed `ApiFailure` value (`Http` / `Api` / `EmptyBody` / `Malformed`), not as a thrown `Exception` — callers branch on the case
+- All public methods (`login`, `getAccountGroups`, `getAccounts`, `getCategories`, `getTransactions`) return `ApiResult<…>`; `login` returns `ApiResult<Unit>` and stores the token on `Ok`
+- Transport errors (connection refused/timeout) are not modelled by `ApiFailure` and propagate as thrown exceptions
+- Preconditions stay as `IllegalArgumentException` ("Authentication required", "Token cannot be blank")
 
 ### JSON Mapping
 Domain classes use `@SerializedName` for field mapping:
@@ -198,7 +200,7 @@ Configuration loaded via `AppConfig` singleton object.
 
 1. Add method to `HomemoneyApiService` interface with Retrofit annotations
 2. Create response data class with `@SerializedName` annotations
-3. Add convenience method to `HomemoneyApiClient` using `handleResponse()`
+3. Add convenience method to `HomemoneyApiClient` returning `ApiResult<…>` via `interpret()`
 4. Create unit tests in `HomemoneyApiServiceTest`
 5. Create integration tests in `ApiIntegrationTest`
 6. Add edge case tests in `EdgeCaseTest`

--- a/src/main/kotlin/ApiFailure.kt
+++ b/src/main/kotlin/ApiFailure.kt
@@ -1,0 +1,23 @@
+package ru.levar
+
+/**
+ * The single, typed vocabulary of ways an API call can fail.
+ *
+ * Failures are produced at one interpretation point (the response seam in
+ * [HomemoneyApiClient]) and carried across it inside [ApiResult.Err], so callers
+ * branch on the case — e.g. retry only on [Http] 503 — instead of grepping an
+ * exception message.
+ */
+sealed interface ApiFailure {
+    /** Transport succeeded but the server returned a non-2xx HTTP status. */
+    data class Http(val code: Int) : ApiFailure
+
+    /** HTTP 200 whose envelope carried a non-zero API error code. */
+    data class Api(val code: Int, val message: String) : ApiFailure
+
+    /** A successful response with no body to interpret (e.g. HTTP 204 / null body). */
+    data object EmptyBody : ApiFailure
+
+    /** The body could not be parsed as the expected JSON envelope (incl. empty-body "End of input"). */
+    data class Malformed(val cause: Throwable) : ApiFailure
+}

--- a/src/main/kotlin/ApiResult.kt
+++ b/src/main/kotlin/ApiResult.kt
@@ -1,0 +1,20 @@
+package ru.levar
+
+/**
+ * A two-arm result carrying either a success payload [T] or a typed [ApiFailure].
+ *
+ * Kotlin's stdlib `Result` only carries a `Throwable`, so the client uses this small
+ * sealed type to surface failures as values without throwing.
+ */
+sealed interface ApiResult<out T> {
+    data class Ok<out T>(val value: T) : ApiResult<T>
+
+    data class Err(val failure: ApiFailure) : ApiResult<Nothing>
+}
+
+/** Transforms the success payload, leaving an [ApiResult.Err] untouched. */
+inline fun <T, R> ApiResult<T>.map(transform: (T) -> R): ApiResult<R> =
+    when (this) {
+        is ApiResult.Ok -> ApiResult.Ok(transform(value))
+        is ApiResult.Err -> this
+    }

--- a/src/main/kotlin/HomemoneyApiClient.kt
+++ b/src/main/kotlin/HomemoneyApiClient.kt
@@ -1,6 +1,7 @@
 package ru.levar
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.google.gson.JsonParseException
+import com.google.gson.stream.MalformedJsonException
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Response
@@ -12,9 +13,8 @@ import ru.levar.domain.Account
 import ru.levar.domain.AccountGroup
 import ru.levar.domain.Category
 import ru.levar.domain.Transaction
+import java.io.EOFException
 import java.util.concurrent.TimeUnit
-
-private val logger = KotlinLogging.logger {}
 
 class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
     private val apiService: HomemoneyApiService
@@ -56,39 +56,34 @@ class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
         password: String,
         clientId: String,
         clientSecret: String,
-    ): Boolean {
-        return try {
-            val auth = handleResponse(apiService.login(login, password, clientId, clientSecret))
-            token = auth.token
-            true
-        } catch (e: Exception) {
-            logger.error(e) { "Authentication failed: ${e.message}" }
-            false
+    ): ApiResult<Unit> =
+        when (val result = interpret { apiService.login(login, password, clientId, clientSecret) }) {
+            is ApiResult.Ok -> {
+                token = result.value.token
+                ApiResult.Ok(Unit)
+            }
+            is ApiResult.Err -> result
         }
-    }
 
     private fun requireAuthentication() {
         require(_token.isNotBlank()) { "Authentication required. Call login() first." }
     }
 
-    suspend fun getAccountGroups(): List<AccountGroup> {
+    suspend fun getAccountGroups(): ApiResult<List<AccountGroup>> {
         requireAuthentication()
-        val response = apiService.getAccountGroups(token)
-        return handleResponse(response).listAccountGroupInfo
+        return interpret { apiService.getAccountGroups(token) }.map { it.listAccountGroupInfo }
     }
 
-    suspend fun getAccounts(): List<Account> = getAccountGroups().flatMap { it.listAccountInfo }
+    suspend fun getAccounts(): ApiResult<List<Account>> = getAccountGroups().map { groups -> groups.flatMap { it.listAccountInfo } }
 
-    suspend fun getCategories(): List<Category> {
+    suspend fun getCategories(): ApiResult<List<Category>> {
         requireAuthentication()
-        val response = apiService.getCategories(token)
-        return handleResponse(response).listCategory
+        return interpret { apiService.getCategories(token) }.map { it.listCategory }
     }
 
-    suspend fun getTransactions(topCount: Int?): List<Transaction> {
+    suspend fun getTransactions(topCount: Int?): ApiResult<List<Transaction>> {
         requireAuthentication()
-        val response = apiService.getTransactions(token, topCount)
-        return handleResponse(response).listTransaction
+        return interpret { apiService.getTransactions(token, topCount) }.map { it.listTransaction }
     }
 
 //    suspend fun getTransactions(
@@ -121,19 +116,35 @@ class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
 //        return handleResponse(response)
 //    }
 
-    private fun <T : ApiEnvelope> handleResponse(response: Response<T>): T {
+    /**
+     * The single point where a raw HTTP response is interpreted into an [ApiResult].
+     *
+     * Every failure mode is decided here once: a non-2xx status, a null/empty body,
+     * an API-level error on HTTP 200, and a Gson parse failure (including the empty-body
+     * "End of input"). Transport errors (e.g. connection refused/timeout) are not modelled
+     * by [ApiFailure] and propagate as thrown exceptions.
+     */
+    private suspend fun <T : ApiEnvelope> interpret(call: suspend () -> Response<T>): ApiResult<T> {
+        val response =
+            try {
+                call()
+            } catch (e: Exception) {
+                if (e is JsonParseException || e is MalformedJsonException || e is EOFException) {
+                    return ApiResult.Err(ApiFailure.Malformed(e))
+                }
+                throw e
+            }
+
         if (!response.isSuccessful) {
-            throw Exception("Request failed with code ${response.code()}: ${response.message()}")
+            return ApiResult.Err(ApiFailure.Http(response.code()))
         }
 
-        val body =
-            response.body()
-                ?: throw Exception("Request failed: empty response body")
+        val body = response.body() ?: return ApiResult.Err(ApiFailure.EmptyBody)
 
         if (body.error.code != 0) {
-            throw Exception("API error ${body.error.code}: ${body.error.message}")
+            return ApiResult.Err(ApiFailure.Api(body.error.code, body.error.message))
         }
 
-        return body
+        return ApiResult.Ok(body)
     }
 }

--- a/src/test/kotlin/ru/levar/integration/ApiIntegrationTest.kt
+++ b/src/test/kotlin/ru/levar/integration/ApiIntegrationTest.kt
@@ -7,7 +7,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import ru.levar.ApiFailure
+import ru.levar.ApiResult
 import ru.levar.HomemoneyApiClient
+import ru.levar.testutils.expectErr
+import ru.levar.testutils.expectOk
 
 /**
  * Integration tests simulating full user workflows
@@ -143,13 +147,13 @@ class ApiIntegrationTest {
             )
 
             // Act - Execute complete workflow
-            val loginSuccess = apiClient.login("user", "pass", "5", "demo")
-            val accounts = apiClient.getAccounts()
-            val categories = apiClient.getCategories()
-            val transactions = apiClient.getTransactions(10)
+            val loginResult = apiClient.login("user", "pass", "5", "demo")
+            val accounts = apiClient.getAccounts().expectOk()
+            val categories = apiClient.getCategories().expectOk()
+            val transactions = apiClient.getTransactions(10).expectOk()
 
             // Assert
-            assertThat(loginSuccess).isTrue()
+            assertThat(loginResult).isEqualTo(ApiResult.Ok(Unit))
             assertThat(apiClient.token).isEqualTo("workflow-token")
 
             assertThat(accounts).hasSize(1)
@@ -184,10 +188,10 @@ class ApiIntegrationTest {
             )
 
             // Act
-            val loginSuccess = apiClient.login("baduser", "badpass", "5", "demo")
+            val loginResult = apiClient.login("baduser", "badpass", "5", "demo")
 
             // Assert
-            assertThat(loginSuccess).isFalse()
+            assertThat(loginResult).isEqualTo(ApiResult.Err(ApiFailure.Api(401, "Invalid credentials")))
             assertThat(apiClient.token).isEmpty()
             assertThat(mockWebServer.requestCount).isEqualTo(1)
         }
@@ -218,15 +222,11 @@ class ApiIntegrationTest {
             )
 
             // Act & Assert
-            val loginSuccess = apiClient.login("user", "pass", "5", "demo")
-            assertThat(loginSuccess).isTrue()
+            val loginResult = apiClient.login("user", "pass", "5", "demo")
+            assertThat(loginResult).isEqualTo(ApiResult.Ok(Unit))
 
-            try {
-                apiClient.getAccounts()
-                // Should throw exception
-            } catch (e: Exception) {
-                assertThat(e.message).contains("500")
-            }
+            val failure = apiClient.getAccounts().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Http(500))
         }
 
     @Test
@@ -344,9 +344,9 @@ class ApiIntegrationTest {
 
             // Act
             apiClient.login("user", "pass", "5", "demo")
-            val accounts = apiClient.getAccounts()
-            val categories = apiClient.getCategories()
-            val transactions = apiClient.getTransactions(10)
+            val accounts = apiClient.getAccounts().expectOk()
+            val categories = apiClient.getCategories().expectOk()
+            val transactions = apiClient.getTransactions(10).expectOk()
 
             // Assert - Should handle empty lists gracefully
             assertThat(accounts).isEmpty()
@@ -439,7 +439,7 @@ class ApiIntegrationTest {
 
             // Act
             apiClient.login("user", "pass", "5", "demo")
-            val accounts = apiClient.getAccounts()
+            val accounts = apiClient.getAccounts().expectOk()
 
             // Assert - Should flatten all accounts from all groups
             assertThat(accounts).hasSize(3)
@@ -500,7 +500,7 @@ class ApiIntegrationTest {
 
             // Act
             apiClient.login("user", "pass", "5", "demo")
-            val transactions = apiClient.getTransactions(5)
+            val transactions = apiClient.getTransactions(5).expectOk()
 
             // Assert
             assertThat(transactions).hasSize(1)

--- a/src/test/kotlin/ru/levar/testutils/ApiResultAssertions.kt
+++ b/src/test/kotlin/ru/levar/testutils/ApiResultAssertions.kt
@@ -1,0 +1,24 @@
+package ru.levar.testutils
+
+import ru.levar.ApiFailure
+import ru.levar.ApiResult
+
+/**
+ * Unwraps a successful [ApiResult], failing the test with a descriptive message when
+ * it is an [ApiResult.Err]. Keeps success-path assertions reading like before.
+ */
+fun <T> ApiResult<T>.expectOk(): T =
+    when (this) {
+        is ApiResult.Ok -> value
+        is ApiResult.Err -> throw AssertionError("Expected ApiResult.Ok but was Err($failure)")
+    }
+
+/**
+ * Unwraps a failed [ApiResult], returning the [ApiFailure] to branch on, and failing the
+ * test with a descriptive message when it is an [ApiResult.Ok].
+ */
+fun ApiResult<*>.expectErr(): ApiFailure =
+    when (this) {
+        is ApiResult.Ok -> throw AssertionError("Expected ApiResult.Err but was Ok($value)")
+        is ApiResult.Err -> failure
+    }

--- a/src/test/kotlin/ru/levar/unit/EdgeCaseTest.kt
+++ b/src/test/kotlin/ru/levar/unit/EdgeCaseTest.kt
@@ -9,9 +9,13 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import ru.levar.ApiFailure
+import ru.levar.ApiResult
 import ru.levar.HomemoneyApiClient
 import ru.levar.domain.Category
 import ru.levar.domain.Transaction
+import ru.levar.testutils.expectErr
+import ru.levar.testutils.expectOk
 import java.util.concurrent.TimeUnit
 
 /**
@@ -46,20 +50,19 @@ class EdgeCaseTest {
             )
             apiClient.token = "token"
 
-            // Act & Assert
-            assertThrows<Exception> {
-                apiClient.getCategories()
-            }
+            // Act & Assert - an unparseable body surfaces as the Malformed case
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isInstanceOf(ApiFailure.Malformed::class.java)
         }
 
     @Test
-    fun `should handle empty response body`() =
+    fun `should return Malformed when response body is empty`() =
         runTest {
             // Arrange - HTTP 200 with a literal empty body.
             // NOTE: Gson's converter rejects empty input ("End of input ...") before the
-            // client's own null-body guard can run, so an empty body surfaces as a parse
-            // error rather than the seam's "empty response body" message. This test pins
-            // that actual behavior so a future converter/seam change is caught.
+            // client's own null-body guard can run, so an empty body surfaces as the
+            // Malformed case (carrying the parse cause) rather than EmptyBody. This test
+            // pins that actual behavior so a future converter/seam change is caught.
             mockWebServer.enqueue(
                 MockResponse()
                     .setResponseCode(200)
@@ -68,15 +71,13 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act & Assert
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("End of input")
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isInstanceOf(ApiFailure.Malformed::class.java)
+            assertThat((failure as ApiFailure.Malformed).cause.message).contains("End of input")
         }
 
     @Test
-    fun `should throw empty response body when body deserializes to null`() =
+    fun `should return EmptyBody when body deserializes to null`() =
         runTest {
             // Arrange - HTTP 204 No Content: Retrofit returns a successful response
             // with a null body without invoking the Gson converter. This is the path
@@ -87,12 +88,9 @@ class EdgeCaseTest {
             )
             apiClient.token = "token"
 
-            // Act & Assert - seam interprets the null body as the empty-body branch
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("empty response body")
+            // Act & Assert - seam interprets the null body as the EmptyBody case
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.EmptyBody)
         }
 
 //     @Test
@@ -112,16 +110,16 @@ class EdgeCaseTest {
 //     }
 
     @Test
-    fun `should handle connection refused`() =
+    fun `should propagate transport error on connection refused`() =
         runTest {
             // Arrange - Shutdown server to simulate connection refused
             mockWebServer.shutdown()
 
-            // Act - login catches exceptions and returns false
-            val result = apiClient.login("user", "pass", "5", "demo")
-
-            // Assert - Should return false on connection error
-            assertThat(result).isFalse()
+            // Act & Assert - transport failures are not modelled by ApiFailure, so they
+            // propagate as thrown exceptions rather than crossing the typed seam.
+            assertThrows<Exception> {
+                apiClient.login("user", "pass", "5", "demo")
+            }
             assertThat(apiClient.token).isEmpty()
         }
 
@@ -148,7 +146,7 @@ class EdgeCaseTest {
             val result = apiClient.login("user", "pass", "5", "demo")
 
             // Assert - Should succeed despite delay
-            assertThat(result).isTrue()
+            assertThat(result).isEqualTo(ApiResult.Ok(Unit))
             assertThat(apiClient.token).isEqualTo("delayed-token")
         }
 
@@ -176,7 +174,7 @@ class EdgeCaseTest {
             val result = apiClient.login(specialUsername, specialPassword, "5", "demo")
 
             // Assert
-            assertThat(result).isTrue()
+            assertThat(result).isEqualTo(ApiResult.Ok(Unit))
 
             val request = mockWebServer.takeRequest()
             // URL encoding should handle special characters
@@ -228,7 +226,7 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act
-            val result = apiClient.getTransactions(null)
+            val result = apiClient.getTransactions(null).expectOk()
 
             // Assert
             assertThat(result).hasSize(1000)
@@ -374,11 +372,8 @@ class EdgeCaseTest {
             apiClient.token = "invalid-token"
 
             // Act & Assert
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("401")
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Http(401))
         }
 
     @Test
@@ -393,11 +388,8 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act & Assert
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("403")
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Http(403))
         }
 
     @Test
@@ -412,11 +404,8 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act & Assert
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("500")
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Http(500))
         }
 
     @Test
@@ -431,11 +420,8 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act & Assert
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("503")
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Http(503))
         }
 
     @Test
@@ -522,7 +508,7 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act
-            val result = apiClient.getAccountGroups()
+            val result = apiClient.getAccountGroups().expectOk()
 
             // Assert
             assertThat(result[0].listAccountInfo[0].listCurrencyInfo).isEmpty()
@@ -549,9 +535,9 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act - Make concurrent requests
-            val result1 = apiClient.getCategories()
-            val result2 = apiClient.getCategories()
-            val result3 = apiClient.getCategories()
+            val result1 = apiClient.getCategories().expectOk()
+            val result2 = apiClient.getCategories().expectOk()
+            val result3 = apiClient.getCategories().expectOk()
 
             // Assert - All should succeed
             assertThat(result1).isEmpty()
@@ -581,7 +567,7 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act
-            val result = apiClient.getCategories()
+            val result = apiClient.getCategories().expectOk()
 
             // Assert
             assertThat(result).isEmpty()
@@ -606,7 +592,7 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act
-            val result = apiClient.getTransactions(0)
+            val result = apiClient.getTransactions(0).expectOk()
 
             // Assert
             assertThat(result).isEmpty()
@@ -634,7 +620,7 @@ class EdgeCaseTest {
             apiClient.token = "token"
 
             // Act
-            val result = apiClient.getTransactions(-1)
+            val result = apiClient.getTransactions(-1).expectOk()
 
             // Assert
             assertThat(result).isEmpty()

--- a/src/test/kotlin/ru/levar/unit/HomemoneyApiClientEnhancedTest.kt
+++ b/src/test/kotlin/ru/levar/unit/HomemoneyApiClientEnhancedTest.kt
@@ -1,6 +1,5 @@
 package ru.levar.unit
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
@@ -10,10 +9,14 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockWebServer
+import ru.levar.ApiFailure
+import ru.levar.ApiResult
 import ru.levar.HomemoneyApiClient
 import ru.levar.testutils.TestDataFactory
 import ru.levar.testutils.enqueueError
 import ru.levar.testutils.enqueueSuccess
+import ru.levar.testutils.expectErr
+import ru.levar.testutils.expectOk
 import ru.levar.testutils.verifyPath
 import ru.levar.testutils.verifyQueryParam
 
@@ -55,7 +58,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                     )
 
                 // Assert
-                result shouldBe true
+                result shouldBe ApiResult.Ok(Unit)
                 apiClient.token shouldBe TestDataFactory.DEFAULT_TOKEN
 
                 // Verify request
@@ -79,7 +82,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.login("wrong", "credentials", "5", "demo")
 
                 // Assert
-                result shouldBe false
+                result shouldBe ApiResult.Err(ApiFailure.Api(401, "Invalid credentials"))
                 apiClient.token shouldBe ""
             }
         }
@@ -93,7 +96,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 val result = apiClient.login("user", "pass", "5", "demo")
 
                 // Assert
-                result shouldBe false
+                result shouldBe ApiResult.Err(ApiFailure.Http(500))
                 apiClient.token shouldBe ""
             }
         }
@@ -118,7 +121,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.getAccountGroups()
+                val result = apiClient.getAccountGroups().expectOk()
 
                 // Assert
                 result shouldHaveSize 1
@@ -139,7 +142,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val accounts = apiClient.getAccounts()
+                val accounts = apiClient.getAccounts().expectOk()
 
                 // Assert
                 accounts shouldHaveSize 2
@@ -154,7 +157,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueSuccess(TestDataFactory.createEmptyBalanceListResponse())
 
                 // Act
-                val accounts = apiClient.getAccounts()
+                val accounts = apiClient.getAccounts().expectOk()
 
                 // Assert
                 accounts.shouldBeEmpty()
@@ -189,7 +192,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.getCategories()
+                val result = apiClient.getCategories().expectOk()
 
                 // Assert
                 result shouldHaveSize 2
@@ -204,7 +207,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueSuccess(TestDataFactory.createEmptyCategoryListResponse())
 
                 // Act
-                val result = apiClient.getCategories()
+                val result = apiClient.getCategories().expectOk()
 
                 // Assert
                 result.shouldBeEmpty()
@@ -233,7 +236,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.getTransactions(10)
+                val result = apiClient.getTransactions(10).expectOk()
 
                 // Assert
                 result shouldHaveSize 1
@@ -252,7 +255,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueSuccess(TestDataFactory.createEmptyTransactionListResponse())
 
                 // Act
-                val result = apiClient.getTransactions(null)
+                val result = apiClient.getTransactions(null).expectOk()
 
                 // Assert
                 result.shouldBeEmpty()
@@ -270,49 +273,37 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
             apiClient.token = TestDataFactory.DEFAULT_TOKEN
         }
 
-        it("should throw exception on 404 Not Found") {
+        it("should return Http failure on 404 Not Found") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueError(404, "Not Found")
 
                 // Act & Assert
-                val exception =
-                    shouldThrow<Exception> {
-                        apiClient.getCategories()
-                    }
-                exception.message shouldContain "404"
+                apiClient.getCategories().expectErr() shouldBe ApiFailure.Http(404)
             }
         }
 
-        it("should throw exception on 401 Unauthorized") {
+        it("should return Http failure on 401 Unauthorized") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueError(401, "Unauthorized")
 
                 // Act & Assert
-                val exception =
-                    shouldThrow<Exception> {
-                        apiClient.getCategories()
-                    }
-                exception.message shouldContain "401"
+                apiClient.getCategories().expectErr() shouldBe ApiFailure.Http(401)
             }
         }
 
-        it("should throw exception on 500 Internal Server Error") {
+        it("should return Http failure on 500 Internal Server Error") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueError(500, "Internal Server Error")
 
                 // Act & Assert
-                val exception =
-                    shouldThrow<Exception> {
-                        apiClient.getCategories()
-                    }
-                exception.message shouldContain "500"
+                apiClient.getCategories().expectErr() shouldBe ApiFailure.Http(500)
             }
         }
 
-        it("should throw when getTransactions returns API error on HTTP 200") {
+        it("should return Api failure when getTransactions returns API error on HTTP 200") {
             runTest {
                 // Arrange: HTTP 200 with a non-zero API error code
                 mockWebServer.enqueueSuccess(
@@ -324,17 +315,12 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                     """.trimIndent(),
                 )
 
-                // Act & Assert - uniform interpretation surfaces code + message
-                val exception =
-                    shouldThrow<Exception> {
-                        apiClient.getTransactions(10)
-                    }
-                exception.message shouldContain "API error 7"
-                exception.message shouldContain "Token expired"
+                // Act & Assert - uniform interpretation surfaces code + message as one typed case
+                apiClient.getTransactions(10).expectErr() shouldBe ApiFailure.Api(7, "Token expired")
             }
         }
 
-        it("should throw when getAccountGroups returns API error on HTTP 200") {
+        it("should return Api failure when getAccountGroups returns API error on HTTP 200") {
             runTest {
                 // Arrange: HTTP 200 with a non-zero API error code
                 mockWebServer.enqueueSuccess(
@@ -348,13 +334,8 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                     """.trimIndent(),
                 )
 
-                // Act & Assert - uniform interpretation surfaces code + message
-                val exception =
-                    shouldThrow<Exception> {
-                        apiClient.getAccountGroups()
-                    }
-                exception.message shouldContain "API error 7"
-                exception.message shouldContain "Token expired"
+                // Act & Assert - uniform interpretation surfaces code + message as one typed case
+                apiClient.getAccountGroups().expectErr() shouldBe ApiFailure.Api(7, "Token expired")
             }
         }
     }

--- a/src/test/kotlin/ru/levar/unit/HomemoneyApiClientTest.kt
+++ b/src/test/kotlin/ru/levar/unit/HomemoneyApiClientTest.kt
@@ -8,9 +8,11 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import ru.levar.ApiFailure
+import ru.levar.ApiResult
 import ru.levar.HomemoneyApiClient
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import ru.levar.testutils.expectErr
+import ru.levar.testutils.expectOk
 
 /**
  * Unit tests for HomemoneyApiClient
@@ -59,7 +61,7 @@ class HomemoneyApiClientTest {
             val result = apiClient.login("testuser", "testpass", "5", "demo")
 
             // Assert
-            assertTrue(result, "Login should succeed")
+            assertThat(result).isEqualTo(ApiResult.Ok(Unit))
             assertThat(apiClient.token).isEqualTo("test-token-123")
 
             // Verify request was made correctly
@@ -93,12 +95,12 @@ class HomemoneyApiClientTest {
             val result = apiClient.login("wronguser", "wrongpass", "5", "demo")
 
             // Assert
-            assertFalse(result, "Login should fail")
+            assertThat(result).isEqualTo(ApiResult.Err(ApiFailure.Api(1, "Invalid credentials")))
             assertThat(apiClient.token).isEmpty()
         }
 
     @Test
-    fun `login should handle network error gracefully`() =
+    fun `login should return Http failure on server error`() =
         runTest {
             // Arrange
             val mockResponse =
@@ -111,7 +113,7 @@ class HomemoneyApiClientTest {
             val result = apiClient.login("testuser", "testpass", "5", "demo")
 
             // Assert
-            assertFalse(result, "Login should fail on network error")
+            assertThat(result).isEqualTo(ApiResult.Err(ApiFailure.Http(500)))
         }
 
     @Test
@@ -155,7 +157,7 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act
-            val result = apiClient.getAccountGroups()
+            val result = apiClient.getAccountGroups().expectOk()
 
             // Assert
             assertThat(result).hasSize(1)
@@ -238,7 +240,7 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act
-            val result = apiClient.getAccounts()
+            val result = apiClient.getAccounts().expectOk()
 
             // Assert
             assertThat(result).hasSize(3)
@@ -282,7 +284,7 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act
-            val result = apiClient.getCategories()
+            val result = apiClient.getCategories().expectOk()
 
             // Assert
             assertThat(result).hasSize(2)
@@ -336,7 +338,7 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act
-            val result = apiClient.getTransactions(10)
+            val result = apiClient.getTransactions(10).expectOk()
 
             // Assert
             assertThat(result).hasSize(1)
@@ -370,7 +372,7 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act
-            val result = apiClient.getTransactions(null)
+            val result = apiClient.getTransactions(null).expectOk()
 
             // Assert
             assertThat(result).isEmpty()
@@ -382,7 +384,7 @@ class HomemoneyApiClientTest {
         }
 
     @Test
-    fun `getCategories should throw when API returns error code on HTTP 200`() =
+    fun `getCategories should return Api failure when API returns error code on HTTP 200`() =
         runTest {
             // Arrange: HTTP 200 but API-level error in the Error envelope
             val mockResponse =
@@ -399,18 +401,13 @@ class HomemoneyApiClientTest {
             mockWebServer.enqueue(mockResponse)
             apiClient.token = "test-token"
 
-            // Act & Assert - the unified seam must surface both the API error code
-            // and the message in one interpretation
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("API error 5")
-            assertThat(exception.message).contains("Session expired")
+            // Act & Assert - the unified seam surfaces the API code + message as one typed case
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Api(5, "Session expired"))
         }
 
     @Test
-    fun `handleResponse should throw exception on unsuccessful response`() =
+    fun `interpret should return Http failure on unsuccessful response`() =
         runTest {
             // Arrange
             val mockResponse =
@@ -421,11 +418,8 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act & Assert
-            val exception =
-                assertThrows<Exception> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("404")
+            val failure = apiClient.getCategories().expectErr()
+            assertThat(failure).isEqualTo(ApiFailure.Http(404))
         }
 
     @Test
@@ -505,7 +499,7 @@ class HomemoneyApiClientTest {
             apiClient.token = "test-token"
 
             // Act
-            val result = apiClient.getAccounts()
+            val result = apiClient.getAccounts().expectOk()
 
             // Assert
             assertThat(result).isEmpty()


### PR DESCRIPTION
Closes #7.

## What changed

Deepens the single response-handling seam (from `76281ce`) so failures cross it as a **value type** instead of a substring inside a generic `Exception`. Callers can now branch on the failure — e.g. retry only on HTTP 503.

### New types
- `ApiFailure` — sealed vocabulary of failure modes:
  - `Http(code)` — non-2xx HTTP
  - `Api(code, message)` — HTTP 200 with `Error.code != 0`
  - `EmptyBody` — null/204 body
  - `Malformed(cause)` — Gson parse failure, incl. empty-body "End of input"
- `ApiResult<T>` — two-arm result `Ok(value)` / `Err(failure)` with a `map()` helper. Kotlin's stdlib `Result` only carries `Throwable`, so a small custom sealed type is used (no new dependency).

### Seam
- `handleResponse` (which threw) → `interpret()`, the single point that decides **every** failure mode once and returns `ApiResult`. No caller reconstructs error meaning from a string.

### Public API (breaking)
- `login` → `ApiResult<Unit>` (stores token on `Ok`)
- `getAccountGroups` / `getAccounts` / `getCategories` / `getTransactions` → `ApiResult<List<…>>`

### Tests
- The existing `exception.message` / `assertThrows` error assertions now branch on the `ApiFailure` case.
- Added `expectOk()` / `expectErr()` test helpers to keep success-path assertions readable.

## Scope notes / decisions
- **Result shape**: `ApiResult<T>` with the failure arm fixed to `ApiFailure` (vs a fully generic `Result<T, E>`) — avoids shadowing `kotlin.Result` and keeps generics simple.
- **`login` payload**: `ApiResult<Unit>` (token kept as internal side-effect, accessible via `.token`).
- **Transport errors** (connection refused / timeout) are intentionally **not** modelled by `ApiFailure` — they propagate as thrown exceptions, matching the issue's explicit 4-case sealed shape. The connection-refused test now asserts propagation.
- **Preconditions** ("Authentication required", "Token cannot be blank") remain `IllegalArgumentException`.

## Acceptance criteria
- [x] Sealed `ApiFailure` covering non-2xx HTTP, API error on 200, empty/null body, malformed JSON
- [x] Single interpretation point returns a two-arm result, not a thrown `Exception`
- [x] All public methods surface failures through the typed seam
- [x] Existing `exception.message`/`assertThrows` assertions branch on the case
- [x] Error meaning defined in one place (`interpret`)
- [x] All tests pass via MockWebServer; no production endpoints contacted

## Verification
`./gradlew clean ktlintCheck test` → **BUILD SUCCESSFUL**, 87 tests pass, ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)