### PR TITLE
#8 Carry the login-first invariant in the type: introduce Session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,14 @@ Kotlin-based API client for iHomemoney service (https://ihomemoney.com/api/api2.
 ### Core Components
 
 **HomemoneyApiClient** (`src/main/kotlin/HomemoneyApiClient.kt`)
-- Main entry point for API interactions
-- Manages authentication token lifecycle
-- Wraps HomemoneyApiService with convenience methods
-- Provides `getAccounts()` which flattens account groups into account list
-- Error handling and response processing
+- Unauthenticated entry point; its only operation is `authenticate(...)`, which returns `ApiResult<Session>`
+- Holds no token and no mutable auth state — authenticated operations live on `Session`
 - Configurable base URL (defaults to AppConfig.serviceUri)
+
+**Session** (`src/main/kotlin/Session.kt`)
+- Authenticated handle obtained from `HomemoneyApiClient.authenticate(...)`; its constructor is module-internal, so it cannot be fabricated without authenticating
+- Carries the issued token privately and exposes the authenticated calls: `accountGroups()`, `accounts()` (flattens groups), `categories()`, `transactions(topCount)`
+- "Log in before calling anything" is enforced by the type system rather than a runtime guard
 
 **HomemoneyApiService** (`src/main/kotlin/api/HomemoneyApiService.kt`)
 - Retrofit interface defining API endpoints
@@ -94,10 +96,10 @@ All domain models use Gson `@SerializedName` for JSON mapping.
 - Never modify test config to use production URLs
 
 ### Authentication Flow
-1. Call `login(username, password, clientId, clientSecret)` first
-2. Client stores token in `token` property
-3. All subsequent API calls use stored token
-4. Token is passed as query parameter `@Query("Token")`
+1. Call `authenticate(username, password, clientId, clientSecret)` — returns `ApiResult<Session>`
+2. On `Ok`, the `Session` holds the issued token privately; on `Err`, the typed `ApiFailure` carries why
+3. All authenticated calls hang off the `Session`, so data methods are unreachable without one (compile-time)
+4. Token is attached by `Session` as query parameter `@Query("Token")`
 
 ## Code Patterns
 
@@ -110,11 +112,10 @@ suspend fun getAccounts(): List<Account> {
 ```
 
 ### Response Handling
-- `interpret<T>()` is the single seam: it validates HTTP status, the response body, and the API `Error.code` at one point, returning an `ApiResult<T>` (`Ok`/`Err`)
+- `interpret<T>()` (top-level `internal` in `Interpret.kt`) is the single seam: it validates HTTP status, the response body, and the API `Error.code` at one point, returning an `ApiResult<T>` (`Ok`/`Err`). It is shared by `authenticate` and every `Session` call.
 - Failures cross the seam as a typed `ApiFailure` value (`Http` / `Api` / `EmptyBody` / `Malformed`), not as a thrown `Exception` — callers branch on the case
-- All public methods (`login`, `getAccountGroups`, `getAccounts`, `getCategories`, `getTransactions`) return `ApiResult<…>`; `login` returns `ApiResult<Unit>` and stores the token on `Ok`
+- `HomemoneyApiClient.authenticate(...)` returns `ApiResult<Session>`; `Session.accountGroups()`, `accounts()`, `categories()`, `transactions(...)` each return `ApiResult<…>`
 - Transport errors (connection refused/timeout) are not modelled by `ApiFailure` and propagate as thrown exceptions
-- Preconditions stay as `IllegalArgumentException` ("Authentication required", "Token cannot be blank")
 
 ### JSON Mapping
 Domain classes use `@SerializedName` for field mapping:
@@ -126,22 +127,15 @@ data class AuthResponse(
 ```
 
 ### Account Flattening
-`getAccounts()` convenience method flattens account groups:
+`Session.accounts()` convenience method flattens account groups, mapping over the `ApiResult`:
 ```kotlin
-suspend fun getAccounts(): List<Account> {
-    val accGroups = getAccountGroups()
-    return accGroups.listAccountGroupInfo.flatMap { it.listAccountInfo }
-}
+suspend fun accounts(): ApiResult<List<Account>> =
+    accountGroups().map { groups -> groups.flatMap { it.listAccountInfo } }
 ```
 
-## Commented-Out Functionality
+## Not Yet Implemented
 
-Several features are commented out in HomemoneyApiClient:
-- Alternative `getTransactions()` with filtering (startDate, endDate, accountId, categoryId, pagination)
-- `createTransaction(transaction: Transaction)`
-- `getCurrencies()`
-
-These are NOT implemented or tested. Do not assume they work.
+Filtered `transactions(...)` (startDate, endDate, accountId, categoryId, pagination), `createTransaction(...)`, and `getCurrencies()` are not implemented or tested. Do not assume they work.
 
 ## Test Structure
 
@@ -200,7 +194,7 @@ Configuration loaded via `AppConfig` singleton object.
 
 1. Add method to `HomemoneyApiService` interface with Retrofit annotations
 2. Create response data class with `@SerializedName` annotations
-3. Add convenience method to `HomemoneyApiClient` returning `ApiResult<…>` via `interpret()`
+3. Add the authenticated call to `Session` returning `ApiResult<…>` via `interpret()` (or `authenticate`-style on the client if it is an unauthenticated endpoint)
 4. Create unit tests in `HomemoneyApiServiceTest`
 5. Create integration tests in `ApiIntegrationTest`
 6. Add edge case tests in `EdgeCaseTest`

--- a/src/main/kotlin/HomemoneyApiClient.kt
+++ b/src/main/kotlin/HomemoneyApiClient.kt
@@ -1,31 +1,22 @@
 package ru.levar
 
-import com.google.gson.JsonParseException
-import com.google.gson.stream.MalformedJsonException
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import ru.levar.api.HomemoneyApiService
-import ru.levar.api.dto.ApiEnvelope
-import ru.levar.domain.Account
-import ru.levar.domain.AccountGroup
-import ru.levar.domain.Category
-import ru.levar.domain.Transaction
-import java.io.EOFException
 import java.util.concurrent.TimeUnit
 
+/**
+ * Entry point to the iHomemoney API.
+ *
+ * The client is unauthenticated: its only operation is [authenticate], which exchanges
+ * credentials for a [Session]. Authenticated operations live on [Session], so they are
+ * unreachable without first authenticating — the "log in first" invariant is enforced by
+ * the type system rather than by a runtime guard repeated in every method.
+ */
 class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
     private val apiService: HomemoneyApiService
-    private var _token: String = ""
-
-    var token: String
-        get() = _token
-        set(value) {
-            require(value.isNotBlank()) { "Token cannot be blank" }
-            _token = value
-        }
 
     init {
         val loggingInterceptor =
@@ -51,100 +42,28 @@ class HomemoneyApiClient(baseUrl: String = AppConfig.serviceUri) {
         apiService = retrofit.create(HomemoneyApiService::class.java)
     }
 
-    suspend fun login(
+    /**
+     * Exchanges credentials for an authenticated [Session].
+     *
+     * Returns the same typed seam as every other call: an [ApiResult.Err] carries *why*
+     * authentication failed (wrong password vs. server error vs. malformed body) instead of
+     * collapsing every cause into a bare `false`.
+     */
+    suspend fun authenticate(
         login: String,
         password: String,
         clientId: String,
         clientSecret: String,
-    ): ApiResult<Unit> =
-        when (val result = interpret { apiService.login(login, password, clientId, clientSecret) }) {
-            is ApiResult.Ok -> {
-                token = result.value.token
-                ApiResult.Ok(Unit)
-            }
-            is ApiResult.Err -> result
-        }
-
-    private fun requireAuthentication() {
-        require(_token.isNotBlank()) { "Authentication required. Call login() first." }
-    }
-
-    suspend fun getAccountGroups(): ApiResult<List<AccountGroup>> {
-        requireAuthentication()
-        return interpret { apiService.getAccountGroups(token) }.map { it.listAccountGroupInfo }
-    }
-
-    suspend fun getAccounts(): ApiResult<List<Account>> = getAccountGroups().map { groups -> groups.flatMap { it.listAccountInfo } }
-
-    suspend fun getCategories(): ApiResult<List<Category>> {
-        requireAuthentication()
-        return interpret { apiService.getCategories(token) }.map { it.listCategory }
-    }
-
-    suspend fun getTransactions(topCount: Int?): ApiResult<List<Transaction>> {
-        requireAuthentication()
-        return interpret { apiService.getTransactions(token, topCount) }.map { it.listTransaction }
-    }
-
-//    suspend fun getTransactions(
-//        startDate: String? = null,
-//        endDate: String? = null,
-//        accountId: String? = null,
-//        categoryId: String? = null,
-//        page: Int? = null,
-//        pageSize: Int? = null
-//    ): List<Transaction> {
-//        val response = apiService.getTransactions(
-//            token,
-//            startDate,
-//            endDate,
-//            accountId,
-//            categoryId,
-//            page,
-//            pageSize
-//        )
-//        return handleResponse(response)
-//    }
-
-//    suspend fun createTransaction(transaction: Transaction): String {
-//        val response = apiService.createTransaction(token, transaction)
-//        return handleResponse(response)
-//    }
-
-//    suspend fun getCurrencies(): List<Currency> {
-//        val response = apiService.getCurrencies(token)
-//        return handleResponse(response)
-//    }
+    ): ApiResult<Session> =
+        interpret { apiService.login(login, password, clientId, clientSecret) }
+            .map { Session(apiService, it.token) }
 
     /**
-     * The single point where a raw HTTP response is interpreted into an [ApiResult].
+     * Builds a [Session] for a known token without a network round-trip.
      *
-     * Every failure mode is decided here once: a non-2xx status, a null/empty body,
-     * an API-level error on HTTP 200, and a Gson parse failure (including the empty-body
-     * "End of input"). Transport errors (e.g. connection refused/timeout) are not modelled
-     * by [ApiFailure] and propagate as thrown exceptions.
+     * Module-internal test seam: it lets authenticated-call tests exercise [Session] directly
+     * while keeping the public surface honest — library consumers can still only obtain a
+     * [Session] through [authenticate].
      */
-    private suspend fun <T : ApiEnvelope> interpret(call: suspend () -> Response<T>): ApiResult<T> {
-        val response =
-            try {
-                call()
-            } catch (e: Exception) {
-                if (e is JsonParseException || e is MalformedJsonException || e is EOFException) {
-                    return ApiResult.Err(ApiFailure.Malformed(e))
-                }
-                throw e
-            }
-
-        if (!response.isSuccessful) {
-            return ApiResult.Err(ApiFailure.Http(response.code()))
-        }
-
-        val body = response.body() ?: return ApiResult.Err(ApiFailure.EmptyBody)
-
-        if (body.error.code != 0) {
-            return ApiResult.Err(ApiFailure.Api(body.error.code, body.error.message))
-        }
-
-        return ApiResult.Ok(body)
-    }
+    internal fun sessionWith(token: String): Session = Session(apiService, token)
 }

--- a/src/main/kotlin/Interpret.kt
+++ b/src/main/kotlin/Interpret.kt
@@ -1,0 +1,42 @@
+package ru.levar
+
+import com.google.gson.JsonParseException
+import com.google.gson.stream.MalformedJsonException
+import retrofit2.Response
+import ru.levar.api.dto.ApiEnvelope
+import java.io.EOFException
+
+/**
+ * The single point where a raw HTTP response is interpreted into an [ApiResult].
+ *
+ * Every failure mode is decided here once: a non-2xx status, a null/empty body,
+ * an API-level error on HTTP 200, and a Gson parse failure (including the empty-body
+ * "End of input"). Transport errors (e.g. connection refused/timeout) are not modelled
+ * by [ApiFailure] and propagate as thrown exceptions.
+ *
+ * Shared by the unauthenticated [HomemoneyApiClient.authenticate] call and every
+ * authenticated [Session] call, so the seam stays in one place regardless of who crosses it.
+ */
+internal suspend fun <T : ApiEnvelope> interpret(call: suspend () -> Response<T>): ApiResult<T> {
+    val response =
+        try {
+            call()
+        } catch (e: Exception) {
+            if (e is JsonParseException || e is MalformedJsonException || e is EOFException) {
+                return ApiResult.Err(ApiFailure.Malformed(e))
+            }
+            throw e
+        }
+
+    if (!response.isSuccessful) {
+        return ApiResult.Err(ApiFailure.Http(response.code()))
+    }
+
+    val body = response.body() ?: return ApiResult.Err(ApiFailure.EmptyBody)
+
+    if (body.error.code != 0) {
+        return ApiResult.Err(ApiFailure.Api(body.error.code, body.error.message))
+    }
+
+    return ApiResult.Ok(body)
+}

--- a/src/main/kotlin/Session.kt
+++ b/src/main/kotlin/Session.kt
@@ -1,0 +1,34 @@
+package ru.levar
+
+import ru.levar.api.HomemoneyApiService
+import ru.levar.domain.Account
+import ru.levar.domain.AccountGroup
+import ru.levar.domain.Category
+import ru.levar.domain.Transaction
+
+/**
+ * An authenticated handle to the iHomemoney API.
+ *
+ * A [Session] is the only way to reach authenticated operations: every data call hangs
+ * off an instance, so "log in before calling anything" is carried by the type rather than
+ * re-checked at runtime in each method. It is obtained from
+ * [HomemoneyApiClient.authenticate]; its constructor is module-internal, so a caller cannot
+ * fabricate one without going through authentication.
+ *
+ * The issued token is held privately here — the one place auth state lives — and attached to
+ * each request.
+ */
+class Session internal constructor(
+    private val apiService: HomemoneyApiService,
+    private val token: String,
+) {
+    suspend fun accountGroups(): ApiResult<List<AccountGroup>> =
+        interpret { apiService.getAccountGroups(token) }.map { it.listAccountGroupInfo }
+
+    suspend fun accounts(): ApiResult<List<Account>> = accountGroups().map { groups -> groups.flatMap { it.listAccountInfo } }
+
+    suspend fun categories(): ApiResult<List<Category>> = interpret { apiService.getCategories(token) }.map { it.listCategory }
+
+    suspend fun transactions(topCount: Int?): ApiResult<List<Transaction>> =
+        interpret { apiService.getTransactions(token, topCount) }.map { it.listTransaction }
+}

--- a/src/test/kotlin/ru/levar/integration/ApiIntegrationTest.kt
+++ b/src/test/kotlin/ru/levar/integration/ApiIntegrationTest.kt
@@ -146,16 +146,13 @@ class ApiIntegrationTest {
                     ),
             )
 
-            // Act - Execute complete workflow
-            val loginResult = apiClient.login("user", "pass", "5", "demo")
-            val accounts = apiClient.getAccounts().expectOk()
-            val categories = apiClient.getCategories().expectOk()
-            val transactions = apiClient.getTransactions(10).expectOk()
+            // Act - Execute complete workflow: authenticate first, then fetch through the Session
+            val session = apiClient.authenticate("user", "pass", "5", "demo").expectOk()
+            val accounts = session.accounts().expectOk()
+            val categories = session.categories().expectOk()
+            val transactions = session.transactions(10).expectOk()
 
             // Assert
-            assertThat(loginResult).isEqualTo(ApiResult.Ok(Unit))
-            assertThat(apiClient.token).isEqualTo("workflow-token")
-
             assertThat(accounts).hasSize(1)
             assertThat(accounts[0].name).isEqualTo("Cash")
 
@@ -188,11 +185,10 @@ class ApiIntegrationTest {
             )
 
             // Act
-            val loginResult = apiClient.login("baduser", "badpass", "5", "demo")
+            val authResult = apiClient.authenticate("baduser", "badpass", "5", "demo")
 
-            // Assert
-            assertThat(loginResult).isEqualTo(ApiResult.Err(ApiFailure.Api(401, "Invalid credentials")))
-            assertThat(apiClient.token).isEmpty()
+            // Assert - no Session is produced; the typed cause crosses the seam
+            assertThat(authResult).isEqualTo(ApiResult.Err(ApiFailure.Api(401, "Invalid credentials")))
             assertThat(mockWebServer.requestCount).isEqualTo(1)
         }
 
@@ -222,10 +218,9 @@ class ApiIntegrationTest {
             )
 
             // Act & Assert
-            val loginResult = apiClient.login("user", "pass", "5", "demo")
-            assertThat(loginResult).isEqualTo(ApiResult.Ok(Unit))
+            val session = apiClient.authenticate("user", "pass", "5", "demo").expectOk()
 
-            val failure = apiClient.getAccounts().expectErr()
+            val failure = session.accounts().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Http(500))
         }
 
@@ -264,10 +259,10 @@ class ApiIntegrationTest {
             }
 
             // Act
-            apiClient.login("user", "pass", "5", "demo")
-            apiClient.getCategories()
-            apiClient.getCategories()
-            apiClient.getCategories()
+            val session = apiClient.authenticate("user", "pass", "5", "demo").expectOk()
+            session.categories()
+            session.categories()
+            session.categories()
 
             // Assert - All requests should use same token
             mockWebServer.takeRequest() // Skip login request
@@ -343,10 +338,10 @@ class ApiIntegrationTest {
             )
 
             // Act
-            apiClient.login("user", "pass", "5", "demo")
-            val accounts = apiClient.getAccounts().expectOk()
-            val categories = apiClient.getCategories().expectOk()
-            val transactions = apiClient.getTransactions(10).expectOk()
+            val session = apiClient.authenticate("user", "pass", "5", "demo").expectOk()
+            val accounts = session.accounts().expectOk()
+            val categories = session.categories().expectOk()
+            val transactions = session.transactions(10).expectOk()
 
             // Assert - Should handle empty lists gracefully
             assertThat(accounts).isEmpty()
@@ -438,8 +433,8 @@ class ApiIntegrationTest {
             )
 
             // Act
-            apiClient.login("user", "pass", "5", "demo")
-            val accounts = apiClient.getAccounts().expectOk()
+            val session = apiClient.authenticate("user", "pass", "5", "demo").expectOk()
+            val accounts = session.accounts().expectOk()
 
             // Assert - Should flatten all accounts from all groups
             assertThat(accounts).hasSize(3)
@@ -499,8 +494,8 @@ class ApiIntegrationTest {
             )
 
             // Act
-            apiClient.login("user", "pass", "5", "demo")
-            val transactions = apiClient.getTransactions(5).expectOk()
+            val session = apiClient.authenticate("user", "pass", "5", "demo").expectOk()
+            val transactions = session.transactions(5).expectOk()
 
             // Assert
             assertThat(transactions).hasSize(1)

--- a/src/test/kotlin/ru/levar/testutils/BaseApiTest.kt
+++ b/src/test/kotlin/ru/levar/testutils/BaseApiTest.kt
@@ -4,6 +4,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import ru.levar.HomemoneyApiClient
+import ru.levar.Session
 
 /**
  * Base test class providing common setup for API tests
@@ -33,11 +34,11 @@ abstract class BaseApiTest {
     }
 
     /**
-     * Helper to set token on API client for authenticated requests
+     * Helper to obtain an authenticated [Session] for a known token without a network
+     * round-trip, so authenticated-call tests can fetch data through the type that carries
+     * the "log in first" invariant.
      */
-    protected fun authenticateClient(token: String = TestDataFactory.DEFAULT_TOKEN) {
-        apiClient.token = token
-    }
+    protected fun authenticatedSession(token: String = TestDataFactory.DEFAULT_TOKEN): Session = apiClient.sessionWith(token)
 
     /**
      * Helper to enqueue a successful login response

--- a/src/test/kotlin/ru/levar/unit/EdgeCaseTest.kt
+++ b/src/test/kotlin/ru/levar/unit/EdgeCaseTest.kt
@@ -48,10 +48,10 @@ class EdgeCaseTest {
                     .setResponseCode(200)
                     .setBody("{invalid json"),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act & Assert - an unparseable body surfaces as the Malformed case
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isInstanceOf(ApiFailure.Malformed::class.java)
         }
 
@@ -68,10 +68,10 @@ class EdgeCaseTest {
                     .setResponseCode(200)
                     .setBody(""),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act & Assert
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isInstanceOf(ApiFailure.Malformed::class.java)
             assertThat((failure as ApiFailure.Malformed).cause.message).contains("End of input")
         }
@@ -86,10 +86,10 @@ class EdgeCaseTest {
                 MockResponse()
                     .setResponseCode(204),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act & Assert - seam interprets the null body as the EmptyBody case
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.EmptyBody)
         }
 
@@ -118,9 +118,8 @@ class EdgeCaseTest {
             // Act & Assert - transport failures are not modelled by ApiFailure, so they
             // propagate as thrown exceptions rather than crossing the typed seam.
             assertThrows<Exception> {
-                apiClient.login("user", "pass", "5", "demo")
+                apiClient.authenticate("user", "pass", "5", "demo")
             }
-            assertThat(apiClient.token).isEmpty()
         }
 
     @Test
@@ -143,11 +142,10 @@ class EdgeCaseTest {
             )
 
             // Act
-            val result = apiClient.login("user", "pass", "5", "demo")
+            val result = apiClient.authenticate("user", "pass", "5", "demo")
 
-            // Assert - Should succeed despite delay
-            assertThat(result).isEqualTo(ApiResult.Ok(Unit))
-            assertThat(apiClient.token).isEqualTo("delayed-token")
+            // Assert - Should succeed despite delay, yielding a Session
+            assertThat(result).isInstanceOf(ApiResult.Ok::class.java)
         }
 
     @Test
@@ -171,10 +169,10 @@ class EdgeCaseTest {
             // Act
             val specialUsername = "user@email.com"
             val specialPassword = "p@ssw0rd!#$%"
-            val result = apiClient.login(specialUsername, specialPassword, "5", "demo")
+            val result = apiClient.authenticate(specialUsername, specialPassword, "5", "demo")
 
             // Assert
-            assertThat(result).isEqualTo(ApiResult.Ok(Unit))
+            assertThat(result).isInstanceOf(ApiResult.Ok::class.java)
 
             val request = mockWebServer.takeRequest()
             // URL encoding should handle special characters
@@ -223,10 +221,10 @@ class EdgeCaseTest {
                         """.trimIndent(),
                     ),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act
-            val result = apiClient.getTransactions(null).expectOk()
+            val result = session.transactions(null).expectOk()
 
             // Assert
             assertThat(result).hasSize(1000)
@@ -347,18 +345,10 @@ class EdgeCaseTest {
         assertThat(category.fullName).isEmpty()
     }
 
-    @Test
-    fun `should handle null token in requests`() =
-        runTest {
-            // Arrange - token is empty by default
-
-            // Act & Assert - should throw when calling API without authentication
-            val exception =
-                assertThrows<IllegalArgumentException> {
-                    apiClient.getCategories()
-                }
-            assertThat(exception.message).contains("Authentication required")
-        }
+    // NOTE: The former `should handle null token in requests` test is gone by design.
+    // Calling a data method without authenticating is no longer a runtime throw to assert
+    // on — it is unreachable code (there is no data method outside a Session), so the misuse
+    // is now a compile error rather than an IllegalArgumentException.
 
     @Test
     fun `should handle HTTP 401 Unauthorized`() =
@@ -369,10 +359,10 @@ class EdgeCaseTest {
                     .setResponseCode(401)
                     .setBody("Unauthorized"),
             )
-            apiClient.token = "invalid-token"
+            val session = apiClient.sessionWith("invalid-token")
 
             // Act & Assert
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Http(401))
         }
 
@@ -385,10 +375,10 @@ class EdgeCaseTest {
                     .setResponseCode(403)
                     .setBody("Forbidden"),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act & Assert
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Http(403))
         }
 
@@ -401,10 +391,10 @@ class EdgeCaseTest {
                     .setResponseCode(500)
                     .setBody("Internal Server Error"),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act & Assert
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Http(500))
         }
 
@@ -417,10 +407,10 @@ class EdgeCaseTest {
                     .setResponseCode(503)
                     .setBody("Service Unavailable"),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act & Assert
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Http(503))
         }
 
@@ -505,10 +495,10 @@ class EdgeCaseTest {
                         """.trimIndent(),
                     ),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act
-            val result = apiClient.getAccountGroups().expectOk()
+            val result = session.accountGroups().expectOk()
 
             // Assert
             assertThat(result[0].listAccountInfo[0].listCurrencyInfo).isEmpty()
@@ -532,12 +522,12 @@ class EdgeCaseTest {
                         ),
                 )
             }
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act - Make concurrent requests
-            val result1 = apiClient.getCategories().expectOk()
-            val result2 = apiClient.getCategories().expectOk()
-            val result3 = apiClient.getCategories().expectOk()
+            val result1 = session.categories().expectOk()
+            val result2 = session.categories().expectOk()
+            val result3 = session.categories().expectOk()
 
             // Assert - All should succeed
             assertThat(result1).isEmpty()
@@ -564,10 +554,10 @@ class EdgeCaseTest {
                     .setResponseCode(200)
                     .setBody(responseWithBOM),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act
-            val result = apiClient.getCategories().expectOk()
+            val result = session.categories().expectOk()
 
             // Assert
             assertThat(result).isEmpty()
@@ -589,10 +579,10 @@ class EdgeCaseTest {
                         """.trimIndent(),
                     ),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act
-            val result = apiClient.getTransactions(0).expectOk()
+            val result = session.transactions(0).expectOk()
 
             // Assert
             assertThat(result).isEmpty()
@@ -617,10 +607,10 @@ class EdgeCaseTest {
                         """.trimIndent(),
                     ),
             )
-            apiClient.token = "token"
+            val session = apiClient.sessionWith("token")
 
             // Act
-            val result = apiClient.getTransactions(-1).expectOk()
+            val result = session.transactions(-1).expectOk()
 
             // Assert
             assertThat(result).isEmpty()

--- a/src/test/kotlin/ru/levar/unit/HomemoneyApiClientEnhancedTest.kt
+++ b/src/test/kotlin/ru/levar/unit/HomemoneyApiClientEnhancedTest.kt
@@ -12,6 +12,7 @@ import okhttp3.mockwebserver.MockWebServer
 import ru.levar.ApiFailure
 import ru.levar.ApiResult
 import ru.levar.HomemoneyApiClient
+import ru.levar.Session
 import ru.levar.testutils.TestDataFactory
 import ru.levar.testutils.enqueueError
 import ru.levar.testutils.enqueueSuccess
@@ -30,6 +31,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
 
     lateinit var mockWebServer: MockWebServer
     lateinit var apiClient: HomemoneyApiClient
+    lateinit var session: Session
 
     beforeTest {
         mockWebServer = MockWebServer()
@@ -43,23 +45,22 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
 
     describe("Authentication") {
 
-        it("should successfully login with valid credentials") {
+        it("should successfully authenticate with valid credentials") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueSuccess(TestDataFactory.createSuccessfulAuthResponse())
 
                 // Act
                 val result =
-                    apiClient.login(
+                    apiClient.authenticate(
                         TestDataFactory.DEFAULT_USERNAME,
                         TestDataFactory.DEFAULT_PASSWORD,
                         TestDataFactory.DEFAULT_CLIENT_ID,
                         TestDataFactory.DEFAULT_CLIENT_SECRET,
                     )
 
-                // Assert
-                result shouldBe ApiResult.Ok(Unit)
-                apiClient.token shouldBe TestDataFactory.DEFAULT_TOKEN
+                // Assert - success yields a Session
+                result.expectOk()
 
                 // Verify request
                 val request = mockWebServer.takeRequest()
@@ -71,7 +72,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
             }
         }
 
-        it("should fail login with invalid credentials") {
+        it("should fail authentication with invalid credentials") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueSuccess(
@@ -79,25 +80,23 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.login("wrong", "credentials", "5", "demo")
+                val result = apiClient.authenticate("wrong", "credentials", "5", "demo")
 
-                // Assert
+                // Assert - no Session; the typed cause is carried instead of a bare false
                 result shouldBe ApiResult.Err(ApiFailure.Api(401, "Invalid credentials"))
-                apiClient.token shouldBe ""
             }
         }
 
-        it("should handle HTTP error during login") {
+        it("should handle HTTP error during authentication") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueError(500, "Internal Server Error")
 
                 // Act
-                val result = apiClient.login("user", "pass", "5", "demo")
+                val result = apiClient.authenticate("user", "pass", "5", "demo")
 
                 // Assert
                 result shouldBe ApiResult.Err(ApiFailure.Http(500))
-                apiClient.token shouldBe ""
             }
         }
     }
@@ -105,7 +104,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
     describe("Account Management") {
 
         beforeTest {
-            apiClient.token = TestDataFactory.DEFAULT_TOKEN
+            session = apiClient.sessionWith(TestDataFactory.DEFAULT_TOKEN)
         }
 
         it("should retrieve account groups") {
@@ -121,7 +120,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.getAccountGroups().expectOk()
+                val result = session.accountGroups().expectOk()
 
                 // Assert
                 result shouldHaveSize 1
@@ -142,7 +141,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val accounts = apiClient.getAccounts().expectOk()
+                val accounts = session.accounts().expectOk()
 
                 // Assert
                 accounts shouldHaveSize 2
@@ -157,7 +156,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueSuccess(TestDataFactory.createEmptyBalanceListResponse())
 
                 // Act
-                val accounts = apiClient.getAccounts().expectOk()
+                val accounts = session.accounts().expectOk()
 
                 // Assert
                 accounts.shouldBeEmpty()
@@ -168,7 +167,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
     describe("Category Operations") {
 
         beforeTest {
-            apiClient.token = TestDataFactory.DEFAULT_TOKEN
+            session = apiClient.sessionWith(TestDataFactory.DEFAULT_TOKEN)
         }
 
         it("should retrieve categories") {
@@ -192,7 +191,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.getCategories().expectOk()
+                val result = session.categories().expectOk()
 
                 // Assert
                 result shouldHaveSize 2
@@ -207,7 +206,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueSuccess(TestDataFactory.createEmptyCategoryListResponse())
 
                 // Act
-                val result = apiClient.getCategories().expectOk()
+                val result = session.categories().expectOk()
 
                 // Assert
                 result.shouldBeEmpty()
@@ -218,7 +217,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
     describe("Transaction Operations") {
 
         beforeTest {
-            apiClient.token = TestDataFactory.DEFAULT_TOKEN
+            session = apiClient.sessionWith(TestDataFactory.DEFAULT_TOKEN)
         }
 
         it("should retrieve transactions with topCount parameter") {
@@ -236,7 +235,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                val result = apiClient.getTransactions(10).expectOk()
+                val result = session.transactions(10).expectOk()
 
                 // Assert
                 result shouldHaveSize 1
@@ -255,7 +254,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueSuccess(TestDataFactory.createEmptyTransactionListResponse())
 
                 // Act
-                val result = apiClient.getTransactions(null).expectOk()
+                val result = session.transactions(null).expectOk()
 
                 // Assert
                 result.shouldBeEmpty()
@@ -270,7 +269,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
     describe("Error Handling") {
 
         beforeTest {
-            apiClient.token = TestDataFactory.DEFAULT_TOKEN
+            session = apiClient.sessionWith(TestDataFactory.DEFAULT_TOKEN)
         }
 
         it("should return Http failure on 404 Not Found") {
@@ -279,7 +278,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueError(404, "Not Found")
 
                 // Act & Assert
-                apiClient.getCategories().expectErr() shouldBe ApiFailure.Http(404)
+                session.categories().expectErr() shouldBe ApiFailure.Http(404)
             }
         }
 
@@ -289,7 +288,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueError(401, "Unauthorized")
 
                 // Act & Assert
-                apiClient.getCategories().expectErr() shouldBe ApiFailure.Http(401)
+                session.categories().expectErr() shouldBe ApiFailure.Http(401)
             }
         }
 
@@ -299,7 +298,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 mockWebServer.enqueueError(500, "Internal Server Error")
 
                 // Act & Assert
-                apiClient.getCategories().expectErr() shouldBe ApiFailure.Http(500)
+                session.categories().expectErr() shouldBe ApiFailure.Http(500)
             }
         }
 
@@ -316,7 +315,7 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act & Assert - uniform interpretation surfaces code + message as one typed case
-                apiClient.getTransactions(10).expectErr() shouldBe ApiFailure.Api(7, "Token expired")
+                session.transactions(10).expectErr() shouldBe ApiFailure.Api(7, "Token expired")
             }
         }
 
@@ -335,18 +334,14 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act & Assert - uniform interpretation surfaces code + message as one typed case
-                apiClient.getAccountGroups().expectErr() shouldBe ApiFailure.Api(7, "Token expired")
+                session.accountGroups().expectErr() shouldBe ApiFailure.Api(7, "Token expired")
             }
         }
     }
 
-    describe("Token Management") {
+    describe("Session lifecycle") {
 
-        it("should have empty token initially") {
-            apiClient.token shouldBe ""
-        }
-
-        it("should store token after successful login") {
+        it("should yield a Session on successful authentication") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueSuccess(
@@ -357,23 +352,23 @@ class HomemoneyApiClientEnhancedTest : DescribeSpec({
                 )
 
                 // Act
-                apiClient.login("user", "pass", "5", "demo")
+                val result = apiClient.authenticate("user", "pass", "5", "demo")
 
-                // Assert
-                apiClient.token shouldBe "new-access-token"
+                // Assert - authentication concentrates auth state in the returned Session
+                result.expectOk()
             }
         }
 
-        it("should not store token after failed login") {
+        it("should yield no Session on failed authentication") {
             runTest {
                 // Arrange
                 mockWebServer.enqueueSuccess(TestDataFactory.createFailedAuthResponse())
 
                 // Act
-                apiClient.login("user", "pass", "5", "demo")
+                val result = apiClient.authenticate("user", "pass", "5", "demo")
 
-                // Assert
-                apiClient.token shouldBe ""
+                // Assert - a failed auth produces an Err, not a usable handle
+                result.expectErr()
             }
         }
     }

--- a/src/test/kotlin/ru/levar/unit/HomemoneyApiClientTest.kt
+++ b/src/test/kotlin/ru/levar/unit/HomemoneyApiClientTest.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import ru.levar.ApiFailure
 import ru.levar.ApiResult
 import ru.levar.HomemoneyApiClient
@@ -40,7 +39,48 @@ class HomemoneyApiClientTest {
     }
 
     @Test
-    fun `login should succeed with valid credentials`() =
+    fun `authenticate should yield a Session that fetches data with the issued token`() =
+        runTest {
+            // Arrange - login issues a token, then a data response for the Session call
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "Error": {"code": 0, "message": ""},
+                            "access_token": "session-token",
+                            "refresh_token": "refresh"
+                        }
+                        """.trimIndent(),
+                    ),
+            )
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "ListCategory": [],
+                            "Error": {"code": 0, "message": ""}
+                        }
+                        """.trimIndent(),
+                    ),
+            )
+
+            // Act - obtain a Session, then reach a data call only through it
+            val session = apiClient.authenticate("testuser", "testpass", "5", "demo").expectOk()
+            session.categories().expectOk()
+
+            // Assert - the data request carried the token issued by authenticate
+            mockWebServer.takeRequest() // login request
+            val dataRequest = mockWebServer.takeRequest()
+            assertThat(dataRequest.path).contains("CategoryList")
+            assertThat(dataRequest.path).contains("Token=session-token")
+        }
+
+    @Test
+    fun `authenticate should send credentials and succeed with valid login`() =
         runTest {
             // Arrange
             val mockResponse =
@@ -58,11 +98,10 @@ class HomemoneyApiClientTest {
             mockWebServer.enqueue(mockResponse)
 
             // Act
-            val result = apiClient.login("testuser", "testpass", "5", "demo")
+            val result = apiClient.authenticate("testuser", "testpass", "5", "demo")
 
-            // Assert
-            assertThat(result).isEqualTo(ApiResult.Ok(Unit))
-            assertThat(apiClient.token).isEqualTo("test-token-123")
+            // Assert - success yields a Session (not a bare boolean)
+            assertThat(result).isInstanceOf(ApiResult.Ok::class.java)
 
             // Verify request was made correctly
             val request = mockWebServer.takeRequest()
@@ -74,7 +113,7 @@ class HomemoneyApiClientTest {
         }
 
     @Test
-    fun `login should fail with invalid credentials`() =
+    fun `authenticate should fail with the API cause on invalid credentials`() =
         runTest {
             // Arrange
             val mockResponse =
@@ -92,15 +131,14 @@ class HomemoneyApiClientTest {
             mockWebServer.enqueue(mockResponse)
 
             // Act
-            val result = apiClient.login("wronguser", "wrongpass", "5", "demo")
+            val result = apiClient.authenticate("wronguser", "wrongpass", "5", "demo")
 
-            // Assert
+            // Assert - the failure carries why, instead of collapsing to false
             assertThat(result).isEqualTo(ApiResult.Err(ApiFailure.Api(1, "Invalid credentials")))
-            assertThat(apiClient.token).isEmpty()
         }
 
     @Test
-    fun `login should return Http failure on server error`() =
+    fun `authenticate should return Http failure on server error`() =
         runTest {
             // Arrange
             val mockResponse =
@@ -110,7 +148,7 @@ class HomemoneyApiClientTest {
             mockWebServer.enqueue(mockResponse)
 
             // Act
-            val result = apiClient.login("testuser", "testpass", "5", "demo")
+            val result = apiClient.authenticate("testuser", "testpass", "5", "demo")
 
             // Assert
             assertThat(result).isEqualTo(ApiResult.Err(ApiFailure.Http(500)))
@@ -154,10 +192,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act
-            val result = apiClient.getAccountGroups().expectOk()
+            val result = session.accountGroups().expectOk()
 
             // Assert
             assertThat(result).hasSize(1)
@@ -237,10 +275,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act
-            val result = apiClient.getAccounts().expectOk()
+            val result = session.accounts().expectOk()
 
             // Assert
             assertThat(result).hasSize(3)
@@ -281,10 +319,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act
-            val result = apiClient.getCategories().expectOk()
+            val result = session.categories().expectOk()
 
             // Assert
             assertThat(result).hasSize(2)
@@ -335,10 +373,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act
-            val result = apiClient.getTransactions(10).expectOk()
+            val result = session.transactions(10).expectOk()
 
             // Assert
             assertThat(result).hasSize(1)
@@ -369,10 +407,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act
-            val result = apiClient.getTransactions(null).expectOk()
+            val result = session.transactions(null).expectOk()
 
             // Assert
             assertThat(result).isEmpty()
@@ -399,10 +437,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act & Assert - the unified seam surfaces the API code + message as one typed case
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Api(5, "Session expired"))
         }
 
@@ -415,68 +453,12 @@ class HomemoneyApiClientTest {
                     .setResponseCode(404)
                     .setBody("Not Found")
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act & Assert
-            val failure = apiClient.getCategories().expectErr()
+            val failure = session.categories().expectErr()
             assertThat(failure).isEqualTo(ApiFailure.Http(404))
         }
-
-    @Test
-    fun `token should be empty initially`() {
-        // Assert
-        assertThat(apiClient.token).isEmpty()
-    }
-
-    @Test
-    fun `token should be set after successful login`() =
-        runTest {
-            // Arrange
-            val mockResponse =
-                MockResponse()
-                    .setResponseCode(200)
-                    .setBody(
-                        """
-                        {
-                            "Error": {"code": 0, "message": ""},
-                            "access_token": "new-token",
-                            "refresh_token": "new-refresh"
-                        }
-                        """.trimIndent(),
-                    )
-            mockWebServer.enqueue(mockResponse)
-
-            // Act
-            apiClient.login("user", "pass", "5", "demo")
-
-            // Assert
-            assertThat(apiClient.token).isEqualTo("new-token")
-        }
-
-    @Test
-    fun `token setter should reject blank values`() {
-        // Act & Assert
-        val exception =
-            assertThrows<IllegalArgumentException> {
-                apiClient.token = ""
-            }
-        assertThat(exception.message).contains("Token cannot be blank")
-
-        val exception2 =
-            assertThrows<IllegalArgumentException> {
-                apiClient.token = "   "
-            }
-        assertThat(exception2.message).contains("Token cannot be blank")
-    }
-
-    @Test
-    fun `token setter should accept valid values`() {
-        // Act
-        apiClient.token = "valid-token-123"
-
-        // Assert
-        assertThat(apiClient.token).isEqualTo("valid-token-123")
-    }
 
     @Test
     fun `should handle empty account groups`() =
@@ -496,10 +478,10 @@ class HomemoneyApiClientTest {
                         """.trimIndent(),
                     )
             mockWebServer.enqueue(mockResponse)
-            apiClient.token = "test-token"
+            val session = apiClient.sessionWith("test-token")
 
             // Act
-            val result = apiClient.getAccounts().expectOk()
+            val result = session.accounts().expectOk()
 
             // Assert
             assertThat(result).isEmpty()


### PR DESCRIPTION
Closes #8.

## What changed

Replaces the implicit, shared mutable auth state with an explicit `Session` handle, so the "log in before calling anything" invariant is carried by the type system rather than re-checked at runtime in every method.

- **`authenticate(...)` returns `ApiResult<Session>`** — a failed auth carries *why* (`Api` / `Http` / `Malformed`), consistent with every other call, instead of the old `Boolean` that collapsed "wrong password" and "server error" into a cause-less `false`.
- **Authenticated calls hang off `Session`**: `accountGroups()`, `accounts()` (flattener), `categories()`, `transactions(n)`. `Session`'s constructor is module-internal, so a caller cannot reach a data method without first authenticating — auth-ordering misuse is now a **compile error**, not a runtime throw.
- **`requireAuthentication()` and the mutable `token` property/guard are deleted** (not relocated). The issued token lives privately inside `Session`, the one place auth state sits.
- **`interpret()` extracted** to a shared top-level `internal` seam (`Interpret.kt`), used by both `authenticate` and every `Session` call, so the single response-interpretation point from #7 is preserved.

## Tests

- Restructured around obtaining a `Session` first: integration tests exercise the real `authenticate(...)` → `Session` path; authenticated-call unit tests use an `internal sessionWith(token)` test seam (no network round-trip, keeps per-request assertions focused).
- Removed the now-meaningless token-property tests and the runtime `"Authentication required"` test (that misuse no longer compiles).
- **All 82 tests pass via MockWebServer; no production endpoints contacted.**

## Notes

- The entry point `MainTest.kt` was updated locally to the `authenticate` → `Session` flow so the build stays green, but it is `.gitignore`d (it holds real credentials) and therefore not part of this diff.
- Built on the typed error seam from #7 (`ApiFailure`), now merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)